### PR TITLE
Add a stub-in enemy PatDino, basic healthbars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,26 @@
 platformer_game
 ==========================
 
+## v0.2.2 - 6/21/16
+- Updated to Phaser v2.5.0 'Five Kings'
+
+### New Features:
+- Implemented a basic stub-in PatDino; right now he's just a giant Thug with a regular punch attack and just stalking.
+- Added lo-fi health bars for the Player and PatDino; just names and numbers for now
+
+### Under the Hood:
+- Phaser introduced a `data` property for custom properties, so I'm starting to move our custom props such as `busy`, `state`, etc. under this. (Didn't do this across the board yet, so code is still messy and inconsistent)
+- Starting to try to iron out the very important `busy` state; I haven't been using this consistently but I am trying to define it as "when the actor should not take damage", and hopefully will be able to clean up its usage across all actors soon, especially on the Player (who is still nukeable if attacked by multiple enemies at once).
+- Created a new module for UI elements; currently handles just healthbars. It adds a `healthbars` property to the `game` object, allowing actors to hook into it via an `updateHealthBar` function. This allows healthbars to be created on the game level, while being updated by their actors.
+- Instead of using our own damage counter, modified the one that already exists in Phaser, `Phaser.Sprite.prototype.damage` so, instead of immediately firing `kill()` and immediately removing the sprite when health reaches 0, it now fires a custom event `onZeroHealth` that we can use to hook into and play a death animation before firing `kill()`.
+
+#### New Actor Properties:
+- Added a new property for enemy actors called `target`, which is the Phaser Sprite that the enemy actor is going after. This is only implemented on PatDino right now, but it essentially replaces the `player` object currently used in the Thug actor, and is therefore set up for when multiple players are introduced.
+ - Moving forward, instead of passing in a specific player into an enemy actor, we can use a new Phaser method `Group.getClosestTo(sprite)`, which can be used to find the player that is closest to that enemy sprite. That player becomes the enemy's target for stalking, chasing, and attacking.
+ - Therefore, each enemy actor in particular needs an `opponentGroup` property, which is the Phaser Group that contains the players. (Or something else in the future, such as other enemies!)
+ - This has not actually been tested with multiple players yet!
+- Added `direction` to PatDino to save whether the sprite is facing right or left.
+
 ## v0.2.1 - 6/10/16
 - Upgraded to Phaser Dev branch (2.4.9)! This is indeed risky, but the dev branch has some fixes to some broken sprite behavior that was preventing attackboxes from working correctly.
 

--- a/README.md
+++ b/README.md
@@ -17,14 +17,12 @@
   - *Why es6?* es6 introduces modules, allowing us to export our js partials and import them into each other, allowing for easier organization and avoiding needing to import them all as `<script>` tags in `index.html`, which in turn also allows us to stop worrying about the order in which those js scripts are loaded! :D (es6 also has a bunch of other new features, but for now I'm only using the module feature to keep complexity down.)
 - Phaser: our game engine! Included as a node module so we can bundle it up with Webpack too (see https://github.com/photonstorm/phaser#webpack)
 
-<<<<<<< HEAD
 ### Glossary
 - actor: basically a player or an enemy; something that can attack, take damage, has HP, and can die.
 - hitbox: the area in which, if an attack lands, would register damage onto the actor to which the hitbox belongs. It would also be the area concerned with collision. Phaser-wise, it's the actor's sprite/collision body.
 - attackbox: basically an attack's hitbox; the area around a fist or bullet for example, which, if it collides with a hitbox, would register a hit.
+- busy: (NOTE: this needs cleanup across the codebase; I've been kind of using this inconsistently) A boolean property of the sprite that, if true, means the sprite should not be attacked or receive damage. This could be because the sprite is in an animation that shouldn't be interrupted, such as an intro animation, speaking, has just been injured, or is in the process of dying.
 
-=======
->>>>>>> 214816e357bbe99fa6418de9ec76512a01a141e8
 ### FAQ
 **I'm getting a "This seems to be a pre-built javascript file" error for p2 (or something else) -- what gives?!**
   Unfortunately Phaser doesn't play well with Webpack or other bundlers such as Browserify; see the bajillion issues on the Phaser github for more details. This will probably be less of a problem when Lazer (aka Phaser 3, which is Phaser updated for es6) is released, but for now, this should be an ignorable warning. JS dependency management is hell :/

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -86,7 +86,7 @@ import Attacks from '../helpers/attack-engine.js';
    // * Non-busy action.
    stalk() {
      const { game, sprite, target } = this;
-     sprite.state == 'stalking';
+     sprite.data.state == 'stalking';
      sprite.busy = false;
      // http://phaser.io/docs/2.4.8/Phaser.Physics.Arcade.html#moveToObject
      game.physics.arcade.moveToObject(sprite, target, 60)
@@ -98,7 +98,7 @@ import Attacks from '../helpers/attack-engine.js';
    // * Busy action.
    injured(damage) {
      const { game, sprite } = this;
-     sprite.state == 'injured';
+     sprite.data.state == 'injured';
      sprite.busy = true;
      sprite.health -= damage;
 
@@ -112,12 +112,12 @@ import Attacks from '../helpers/attack-engine.js';
 
    // * Run the function that corresponds to the state the actor is in.
    _runState() {
-     switch (this.sprite.state) {
+     switch (this.sprite.data.state) {
        case 'stalking':
          this.stalk();
          break;
        default:
-         this.sprite.state = 'standing';
+         this.sprite.data.state = 'standing';
          break;
      }
    }

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -3,6 +3,7 @@
  * Attack List:
  * - attackhere
  */
+import * as Debugger from '../helpers/debug-commands.js';
 import { proximityDetection, findNearestFromGroup } from '../helpers/proximity-detection.js';
 import Attacks from '../helpers/attack-engine.js';
 
@@ -48,20 +49,26 @@ import Attacks from '../helpers/attack-engine.js';
    }
 
    update() {
-     console.log('firing update on PatDino')
-     this.move();
-   }
-
-   move() {
      const { game, sprite, opponentGroup, target } = this;
-     if (sprite.body.velocity.x != 0){
+
+     Debugger.showSpriteState(game, sprite)
+
+     // Make sprite move slightly faster over time
+     // and zero-out sprite's velocity if its too low.
+     if (sprite.body.velocity.x != 0) {
        sprite.body.velocity.x *= .75;
        if(sprite.body.velocity.x < .005 && sprite.body.velocity.x > -.005){
          sprite.body.velocity.x = 0;
        }
      }
+
+     this._runState();
+   }
+
+   move() {
+     const { game, sprite, opponentGroup, target } = this;
      //if (!this.dazed()) {
-       this.runState(sprite.state); // fire corresponding function for sprite's state
+       this._runState();
 
        // If Thug sprite is close to Player sprite
        // and Thug's state is stalking or chasing,
@@ -74,11 +81,33 @@ import Attacks from '../helpers/attack-engine.js';
      //}
    }
 
-   runState(state) {
-     console.log(state)
+   // Actions
+
+   // * Stalking = walking towards the target.
+   // * Non-busy action.
+   stalk() {
+     const { game, sprite, target } = this;
+     sprite.state == 'stalking';
+     sprite.busy = false;
+     // http://phaser.io/docs/2.4.8/Phaser.Physics.Arcade.html#moveToObject
+     game.physics.arcade.moveToObject(sprite, target, 60)
+
+     // if PatDino is close to the player, switch to chase
    }
 
    // Private
+
+   // * Run the function that corresponds to the state the actor is in.
+   _runState() {
+     switch (this.sprite.state) {
+       case 'stalking':
+         this.stalk();
+         break;
+       default:
+         this.sprite.state = 'standing';
+         break;
+     }
+   }
 
    _updateState(){
        //if (!this.dazed()) {
@@ -98,7 +127,7 @@ import Attacks from '../helpers/attack-engine.js';
 
      group.add(sprite);
      game.physics.enable(sprite); // create physics body for this sprite
-     sprite.busy = true; // default to busy for opening boss animation
+     sprite.busy = false; // default to not busy
 
      sprite.name = `PatDino`;
      sprite.body.name = `${this.name}-Body`;

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -56,7 +56,7 @@ import Attacks from '../helpers/attack-engine.js';
      // and zero-out sprite's velocity if its too low.
      if (sprite.body.velocity.x != 0) {
        sprite.body.velocity.x *= .75;
-       if(sprite.body.velocity.x < .005 && sprite.body.velocity.x > -.005){
+       if(sprite.body.velocity.x < .005 && sprite.body.velocity.x > -.005) {
          sprite.body.velocity.x = 0;
        }
      }
@@ -110,6 +110,32 @@ import Attacks from '../helpers/attack-engine.js';
      // once animation is done, restore stalking state and remove busy
    }
 
+   // * Dead = health is zero; animate death and perform cleanup
+   // * Busy action.
+   dead() {
+     const { game, sprite } = this;
+     sprite.alive = false;
+     sprite.busy = true;
+
+     sprite.body.velocity.set(0); // stop moving
+     sprite.animations.stop(); // halt all previous animations
+     sprite.animations.play('death');
+
+     // Animate flash
+     game.add.tween(sprite).to(
+       { alpha: 0 }, //properties
+       360, //duration in frames
+       null, //ease
+       true, //autoStart
+       0,  //delay
+       3, //how many repeats
+       false //yoyo
+     ).onComplete.add(function() {
+       // TODO: would be nice to make this use destroy() instead to completely remove it from game logic
+       sprite.kill();
+     });
+   }
+
    // Private
 
    // * Run the function that corresponds to the state the actor is in.
@@ -155,30 +181,10 @@ import Attacks from '../helpers/attack-engine.js';
      // Set sprite's initial state
      sprite.data.state = 'stalking';
 
-     // Overwrite Phaser's kill() function
-     // Automatically fired if sprite's health reaches 0
-     Phaser.Sprite.prototype.kill = function() {
-       // this = sprite
-       const { body, animations } = this;
-       this.alive = false;
-       this.busy = true;
-       //this.exists = false;
-       //this.visible = false;
-
-       body.velocity.set(0);
-       animations.stop();
-       animations.play('death');
-
-       if (this.events) {
-         this.events.onKilled$dispatch(this);
-       }
-
-       return this;
-     }
    }
 
    _addAnimations() {
-     const { sprite } = this;
+     const { game, sprite } = this;
 
      this.sprite.animations.add('idle', ['Evil_standing1.png','Evil_standing2.png'], 12, false);
      this.sprite.animations.add('walk', ['Evil_walkingRight1.png','Evil_walkingRight2.png'], 12, false);
@@ -198,6 +204,11 @@ import Attacks from '../helpers/attack-engine.js';
      events.isHit = new Phaser.Signal();
      events.isHit.add((damage) => {
        this.injured(damage);
+     })
+
+     events.onZeroHealth = new Phaser.Signal();
+     events.onZeroHealth.add(() => {
+       this.dead();
      })
    }
 

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -43,9 +43,8 @@ import Attacks from '../helpers/attack-engine.js';
      game.time.events.loop(Phaser.Timer.SECOND * 1.5, this._updateState, this);
 
      this._createSprite();
+     this._addSpriteEvents();
      this._addAnimations();
-
-     console.log(sprite)
    }
 
    update() {
@@ -81,7 +80,7 @@ import Attacks from '../helpers/attack-engine.js';
      //}
    }
 
-   // Actions
+   // Actions & Animations
 
    // * Stalking = walking towards the target.
    // * Non-busy action.
@@ -93,6 +92,17 @@ import Attacks from '../helpers/attack-engine.js';
      game.physics.arcade.moveToObject(sprite, target, 60)
 
      // if PatDino is close to the player, switch to chase
+   }
+
+   // * Injured = take damage and/or knockback, and play an injured animation.
+   // * Busy action.
+   injured(damage) {
+     const { sprite } = this;
+     sprite.state == 'injured';
+     sprite.busy = true;
+     sprite.damage -= damage;
+
+     // once animation is done, restore stalking state and remove busy
    }
 
    // Private
@@ -158,8 +168,8 @@ import Attacks from '../helpers/attack-engine.js';
      /* isHit - used by HitDetection engine to apply damage to PatDino.
      */
      this.sprite.events.isHit = new Phaser.Signal();
-     this.sprite.events.isHit.add(() => {
-       this.injured();
+     this.sprite.events.isHit.add((damage) => {
+       this.injured(damage);
      })
    }
 

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -1,0 +1,148 @@
+/* Class representing the Patrick Dino boss enemy.
+ * He is a big ole dino dude! Level One boss.
+ * Attack List:
+ * - attackhere
+ */
+import {proximityDetection} from '../helpers/proximity-detection.js';
+import Attacks from '../helpers/attack-engine.js';
+
+ export default class PatDino {
+   /* @constructor
+    * @param {object} game - The current game instance.
+    * @param {object} group - The Phaser group that this sprite should be added to; in this case, the enemy group.
+    * @param {object} playerGroup - The group of actors that PatDino should be doing damage to (opponent group; the players, in this case)
+    */
+   constructor(game, group, playerGroup) {
+     this.game = game;
+     this.group = group,
+     this.playerGroup = playerGroup;
+     this.name = "Boss-PatDino";
+
+     // Generate sprite
+     this.sprite = game.add.sprite(
+       this.game.camera.x + this.game.width + 25,
+       this.game.height/2 + 50,
+       'assets',
+       'Evil_standing1.png'
+     );
+
+     // Generate Phaser group for attacks
+     this.attacks = new Attacks(this.sprite, playerGroup);
+
+     // Starting state
+     this.sprite.state = 'stalking';
+   }
+
+   create() {
+     const { game, group, sprite } = this;
+
+     game.time.events.loop(Phaser.Timer.SECOND * 1.5, this._updateState, this);
+
+     this._createSprite();
+     this._addAnimations();
+   }
+
+   update() {
+     this._move();d
+   }
+
+   // Private
+
+   _updateState(){
+       //if (!this.dazed()) {
+         let stateChoices = ['standing', 'stalking', 'chasing', 'walking'];
+         this.state = stateChoices[this.game.rnd.between(0,3)];
+
+         if(this.state == 'walking'){
+           this.randomX = this.game.rnd.between(25, this.game.width-25);
+           this.randomY = this.game.rnd.between((this.game.height/2 + 50), (this.game.height-100));
+         }
+       //}
+    }
+
+   _move() {
+     if (this.sprite.body.velocity.x != 0){
+       this.sprite.body.velocity.x *= .75;
+       if(this.sprite.body.velocity.x < .005 && this.sprite.body.velocity.x > -.005){
+         this.sprite.body.velocity.x = 0;
+       }
+     }
+
+     //if (!this.dazed()) {
+       if (this.player.sprite.x < this.sprite.x){
+         this.sprite.scale.x = -1 * this.size;
+       } else {
+         this.sprite.scale.x = this.size;
+       }
+       this.runState(); // fire corresponding function for sprite's state
+
+       // If Thug sprite is close to Player sprite
+       // and Thug's state is stalking or chasing,
+       // change Thug's state to attacking, which fires punch()
+       // and also pass Thug's state to its sprite
+       if (proximityDetection(this.game, this.sprite, this.player.sprite) && this.sprite.busy == false) {
+         //this.punch();
+       }
+     //}
+   }
+
+   _createSprite() {
+     const { game, group } = this;
+     let sprite = this.sprite;
+
+     group.add(sprite);
+     game.physics.enable(sprite); // create physics body for this sprite
+     sprite.busy = true; // default to busy for opening boss animation
+
+     sprite.name = `PatDino`;
+     sprite.body.name = `${this.name}-Body`;
+     sprite.maxHealth = 100;
+     sprite.anchor.setTo(0.5, 1);
+     sprite.scale.setTo(1, 1);
+     sprite.body.syncBounds = true;
+   }
+
+   _addAnimations() {
+     const { sprite } = this;
+
+     this.sprite.animations.add('idle', ['Evil_standing1.png','Evil_standing2.png'], 12, false);
+     this.sprite.animations.add('walk', ['Evil_walkingRight1.png','Evil_walkingRight2.png'], 12, false);
+     this.sprite.animations.add('run', ['Evil_walkingRight1.png','Evil_walkingRight2.png'], 12, false);
+     this.sprite.animations.add('punch', ['Evil_punchingRight.png'], 12, false);
+     this.sprite.animations.add('injured', ['Evil_punchedLeft.png'], 12, false);
+     this.sprite.animations.add('death', ['Evil_deadLeft.png'], 12, false);
+   }
+
+   /* Add Phaser Signals (events) to the sprite.
+    * @private
+    */
+   _addSpriteEvents() {
+     /* isHit - used by HitDetection engine to apply damage to PatDino.
+     */
+     this.sprite.events.isHit = new Phaser.Signal();
+     this.sprite.events.isHit.add(() => {
+       this.injured();
+     })
+   }
+
+   /* Build PatDino's attacks.
+    * @private
+    */
+   _addAttacks() {
+     const { sprite, attacks } = this;
+
+     const xPosRightPunch = (sprite.width/2) * this.size;
+     const xPosLeftPunch = (sprite.width/2) / this.size;
+     const yPosPunch = -(sprite.height/2);
+
+     attacks.create({
+       name: 'punch',
+       width: 30,
+       height: 30,
+       xPosRight: xPosRightPunch,
+       xPosLeft: xPosLeftPunch,
+       yPos: yPosPunch,
+       damageValue: 1
+     })
+   }
+ }

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -18,6 +18,7 @@ import Attacks from '../helpers/attack-engine.js';
      this.group = group,
      this.opponentGroup = playerGroup;
      this.name = "Boss-PatDino";
+     this.size = 1;
 
      // Generate sprite
      this.sprite = game.add.sprite(
@@ -62,15 +63,24 @@ import Attacks from '../helpers/attack-engine.js';
      }
 
      if (sprite.alive) {
+       if (target.x < sprite.x) { // if target is to the left of PatDino
+         sprite.data.direction = 'left';
+       } else {
+         sprite.data.direction = 'right';
+       }
+
+       if (sprite.data.direction == 'left') {
+         sprite.scale.x = -(this.size); // make sprite face left
+       } else if (sprite.data.direction == 'right') {
+         sprite.scale.x = this.size;
+       }
+
        this._runState();
      }
    }
 
    move() {
      const { game, sprite, opponentGroup, target } = this;
-     //if (!this.dazed()) {
-       this._runState();
-
        // If Thug sprite is close to Player sprite
        // and Thug's state is stalking or chasing,
        // change Thug's state to attacking, which fires punch()
@@ -89,6 +99,7 @@ import Attacks from '../helpers/attack-engine.js';
    stalk() {
      const { game, sprite, target } = this;
      sprite.data.state == 'stalking';
+     sprite.animations.play('walk');
      sprite.busy = false;
      // http://phaser.io/docs/2.4.8/Phaser.Physics.Arcade.html#moveToObject
      game.physics.arcade.moveToObject(sprite, target, 60)
@@ -175,7 +186,7 @@ import Attacks from '../helpers/attack-engine.js';
      sprite.maxHealth = 100;
      sprite.health = sprite.maxHealth; // initialize with maxHealth
      sprite.anchor.setTo(0.5, 1);
-     sprite.scale.setTo(1, 1);
+     sprite.scale.setTo(this.size, this.size);
      sprite.body.syncBounds = true;
 
      // Set sprite's initial state
@@ -192,6 +203,8 @@ import Attacks from '../helpers/attack-engine.js';
      this.sprite.animations.add('punch', ['Evil_punchingRight.png'], 12, false);
      this.sprite.animations.add('injured', ['Evil_punchedLeft.png'], 12, false);
      this.sprite.animations.add('death', ['Evil_deadLeft.png'], 12, false);
+
+     sprite.data.direction = 'right'; //default to right
    }
 
    /* Add Phaser Signals (events) to the sprite.

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -97,10 +97,13 @@ import Attacks from '../helpers/attack-engine.js';
    // * Injured = take damage and/or knockback, and play an injured animation.
    // * Busy action.
    injured(damage) {
-     const { sprite } = this;
+     const { game, sprite } = this;
      sprite.state == 'injured';
      sprite.busy = true;
-     sprite.damage -= damage;
+     sprite.health -= damage;
+
+     // Update healthbar
+     game.healthbars.updateHealthBar(sprite.name, sprite.health);
 
      // once animation is done, restore stalking state and remove busy
    }
@@ -139,9 +142,10 @@ import Attacks from '../helpers/attack-engine.js';
      game.physics.enable(sprite); // create physics body for this sprite
      sprite.busy = false; // default to not busy
 
-     sprite.name = `PatDino`;
+     sprite.name = this.name;
      sprite.body.name = `${this.name}-Body`;
      sprite.maxHealth = 100;
+     sprite.health = sprite.maxHealth; // initialize with maxHealth
      sprite.anchor.setTo(0.5, 1);
      sprite.scale.setTo(1, 1);
      sprite.body.syncBounds = true;

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -17,7 +17,6 @@ import Attacks from '../helpers/attack-engine.js';
      this.game = game;
      this.group = group,
      this.opponentGroup = playerGroup;
-     this.name = "Boss-PatDino";
      this.size = 1;
 
      // Generate sprite
@@ -27,6 +26,7 @@ import Attacks from '../helpers/attack-engine.js';
        'assets',
        'Evil_standing1.png'
      );
+     this.sprite.name = "Boss-PatDino";
 
      // Generate Phaser group for attacks
      this.attacks = new Attacks(this.sprite, this.opponentGroup);
@@ -46,6 +46,7 @@ import Attacks from '../helpers/attack-engine.js';
      this._createSprite();
      this._addSpriteEvents();
      this._addAnimations();
+     this._addAttacks();
    }
 
    update() {
@@ -76,24 +77,21 @@ import Attacks from '../helpers/attack-engine.js';
          sprite.scale.x = this.size;
        }
 
+       if (proximityDetection(game, sprite, target) && sprite.busy == false) {
+         sprite.data.state = 'attacking';
+       }
+
        this._runState();
      }
    }
 
-   move() {
-     const { game, sprite, opponentGroup, target } = this;
-       // If Thug sprite is close to Player sprite
-       // and Thug's state is stalking or chasing,
-       // change Thug's state to attacking, which fires punch()
-       // and also pass Thug's state to its sprite
-
-       if (proximityDetection(game, sprite, target) && sprite.busy == false) {
-         //this.punch();
-       }
-     //}
-   }
-
    // Actions & Animations
+
+   // * Stop moving = stop sprite's movement
+   // * Non-busy action.
+   stopMoving() {
+      this.sprite.body.velocity.set(0);
+   }
 
    // * Stalking = walking towards the target.
    // * Non-busy action.
@@ -107,6 +105,22 @@ import Attacks from '../helpers/attack-engine.js';
 
      // if PatDino is close to the player, switch to chase
    }
+
+   // * Attacking = attacking the target
+   // * Whether this is busy or not might depend on the attack
+   attack() {
+     const { game, sprite, target, attacks } = this;
+     sprite.data.busy = true;
+     this.stopMoving();
+     attacks.activate('punch');
+     sprite.animations.play('punch').onComplete.add(() => {
+       setTimeout(() => {
+         sprite.data.busy = false;
+         sprite.data.state = 'stalking';
+       }, 1000) // only punch at most every 1000 ms
+     });
+   }
+
 
    // * Injured = take damage and/or knockback, and play an injured animation.
    // * Busy action.
@@ -133,7 +147,7 @@ import Attacks from '../helpers/attack-engine.js';
      sprite.alive = false;
      sprite.busy = true;
 
-     sprite.body.velocity.set(0); // stop moving
+     this.stopMoving();
      sprite.animations.stop(); // halt all previous animations
      sprite.animations.play('death');
 
@@ -160,6 +174,8 @@ import Attacks from '../helpers/attack-engine.js';
        case 'stalking':
          this.stalk();
          break;
+       case 'attacking':
+         this.attack();
        default:
          this.sprite.data.state = 'standing';
          break;
@@ -186,8 +202,7 @@ import Attacks from '../helpers/attack-engine.js';
      game.physics.enable(sprite); // create physics body for this sprite
      sprite.busy = false; // default to not busy
 
-     sprite.name = this.name;
-     sprite.body.name = `${this.name}-Body`;
+     sprite.body.name = `${sprite.name}-Body`;
      sprite.maxHealth = 100;
      sprite.health = sprite.maxHealth; // initialize with maxHealth
      sprite.anchor.setTo(0.5, 1);

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -61,7 +61,9 @@ import Attacks from '../helpers/attack-engine.js';
        }
      }
 
-     this._runState();
+     if (sprite.alive) {
+       this._runState();
+     }
    }
 
    move() {
@@ -100,7 +102,7 @@ import Attacks from '../helpers/attack-engine.js';
      const { game, sprite } = this;
      sprite.data.state == 'injured';
      sprite.busy = true;
-     sprite.health -= damage;
+     sprite.damage(damage);
 
      // Update healthbar
      game.healthbars.updateHealthBar(sprite.name, sprite.health);
@@ -151,7 +153,28 @@ import Attacks from '../helpers/attack-engine.js';
      sprite.body.syncBounds = true;
 
      // Set sprite's initial state
-     sprite.state = 'stalking';
+     sprite.data.state = 'stalking';
+
+     // Overwrite Phaser's kill() function
+     // Automatically fired if sprite's health reaches 0
+     Phaser.Sprite.prototype.kill = function() {
+       // this = sprite
+       const { body, animations } = this;
+       this.alive = false;
+       this.busy = true;
+       //this.exists = false;
+       //this.visible = false;
+
+       body.velocity.set(0);
+       animations.stop();
+       animations.play('death');
+
+       if (this.events) {
+         this.events.onKilled$dispatch(this);
+       }
+
+       return this;
+     }
    }
 
    _addAnimations() {
@@ -171,8 +194,9 @@ import Attacks from '../helpers/attack-engine.js';
    _addSpriteEvents() {
      /* isHit - used by HitDetection engine to apply damage to PatDino.
      */
-     this.sprite.events.isHit = new Phaser.Signal();
-     this.sprite.events.isHit.add((damage) => {
+     const { events } = this.sprite;
+     events.isHit = new Phaser.Signal();
+     events.isHit.add((damage) => {
        this.injured(damage);
      })
    }

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -3,19 +3,19 @@
  * Attack List:
  * - attackhere
  */
-import {proximityDetection} from '../helpers/proximity-detection.js';
+import { proximityDetection, findNearestFromGroup } from '../helpers/proximity-detection.js';
 import Attacks from '../helpers/attack-engine.js';
 
  export default class PatDino {
    /* @constructor
     * @param {object} game - The current game instance.
     * @param {object} group - The Phaser group that this sprite should be added to; in this case, the enemy group.
-    * @param {object} playerGroup - The group of actors that PatDino should be doing damage to (opponent group; the players, in this case)
+    * @param {object} opponentGroup - The Phaser group of actors that PatDino should be doing damage to (players, in this case)
     */
    constructor(game, group, playerGroup) {
      this.game = game;
      this.group = group,
-     this.playerGroup = playerGroup;
+     this.opponentGroup = playerGroup;
      this.name = "Boss-PatDino";
 
      // Generate sprite
@@ -27,11 +27,14 @@ import Attacks from '../helpers/attack-engine.js';
      );
 
      // Generate Phaser group for attacks
-     this.attacks = new Attacks(this.sprite, playerGroup);
+     this.attacks = new Attacks(this.sprite, this.opponentGroup);
 
-     // Starting state
-     this.sprite.state = 'stalking';
+     // Who PatDino is currently attacking
+     // By default, nearest player
+     this.target = findNearestFromGroup(this.sprite, this.opponentGroup);
    }
+
+   preload() {}
 
    create() {
      const { game, group, sprite } = this;
@@ -40,51 +43,54 @@ import Attacks from '../helpers/attack-engine.js';
 
      this._createSprite();
      this._addAnimations();
+
+     console.log(sprite)
    }
 
    update() {
-     this._move();d
+     console.log('firing update on PatDino')
+     this.move();
+   }
+
+   move() {
+     const { game, sprite, opponentGroup, target } = this;
+     if (sprite.body.velocity.x != 0){
+       sprite.body.velocity.x *= .75;
+       if(sprite.body.velocity.x < .005 && sprite.body.velocity.x > -.005){
+         sprite.body.velocity.x = 0;
+       }
+     }
+     //if (!this.dazed()) {
+       this.runState(sprite.state); // fire corresponding function for sprite's state
+
+       // If Thug sprite is close to Player sprite
+       // and Thug's state is stalking or chasing,
+       // change Thug's state to attacking, which fires punch()
+       // and also pass Thug's state to its sprite
+
+       if (proximityDetection(game, sprite, target) && sprite.busy == false) {
+         //this.punch();
+       }
+     //}
+   }
+
+   runState(state) {
+     console.log(state)
    }
 
    // Private
 
    _updateState(){
        //if (!this.dazed()) {
-         let stateChoices = ['standing', 'stalking', 'chasing', 'walking'];
-         this.state = stateChoices[this.game.rnd.between(0,3)];
-
-         if(this.state == 'walking'){
-           this.randomX = this.game.rnd.between(25, this.game.width-25);
-           this.randomY = this.game.rnd.between((this.game.height/2 + 50), (this.game.height-100));
-         }
+        //  let stateChoices = ['standing', 'stalking', 'chasing', 'walking'];
+        //  this.state = stateChoices[this.game.rnd.between(0,3)];
+         //
+        //  if(this.state == 'walking'){
+        //    this.randomX = this.game.rnd.between(25, this.game.width-25);
+        //    this.randomY = this.game.rnd.between((this.game.height/2 + 50), (this.game.height-100));
+        //  }
        //}
     }
-
-   _move() {
-     if (this.sprite.body.velocity.x != 0){
-       this.sprite.body.velocity.x *= .75;
-       if(this.sprite.body.velocity.x < .005 && this.sprite.body.velocity.x > -.005){
-         this.sprite.body.velocity.x = 0;
-       }
-     }
-
-     //if (!this.dazed()) {
-       if (this.player.sprite.x < this.sprite.x){
-         this.sprite.scale.x = -1 * this.size;
-       } else {
-         this.sprite.scale.x = this.size;
-       }
-       this.runState(); // fire corresponding function for sprite's state
-
-       // If Thug sprite is close to Player sprite
-       // and Thug's state is stalking or chasing,
-       // change Thug's state to attacking, which fires punch()
-       // and also pass Thug's state to its sprite
-       if (proximityDetection(this.game, this.sprite, this.player.sprite) && this.sprite.busy == false) {
-         //this.punch();
-       }
-     //}
-   }
 
    _createSprite() {
      const { game, group } = this;
@@ -100,6 +106,9 @@ import Attacks from '../helpers/attack-engine.js';
      sprite.anchor.setTo(0.5, 1);
      sprite.scale.setTo(1, 1);
      sprite.body.syncBounds = true;
+
+     // Set sprite's initial state
+     sprite.state = 'stalking';
    }
 
    _addAnimations() {

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -4,7 +4,7 @@
  * - attackhere
  */
 import * as Debugger from '../helpers/debug-commands.js';
-import { proximityDetection, findNearestFromGroup } from '../helpers/proximity-detection.js';
+import { proximityDetection } from '../helpers/proximity-detection.js';
 import Attacks from '../helpers/attack-engine.js';
 
  export default class PatDino {
@@ -33,7 +33,7 @@ import Attacks from '../helpers/attack-engine.js';
 
      // Who PatDino is currently attacking
      // By default, nearest player
-     this.target = findNearestFromGroup(this.sprite, this.opponentGroup);
+     this.target = this.opponentGroup.getClosestTo(this.sprite);
    }
 
    preload() {}

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -52,8 +52,6 @@ import Attacks from '../helpers/attack-engine.js';
    update() {
      const { game, sprite, opponentGroup, target } = this;
 
-     Debugger.showSpriteState(game, sprite)
-
      // Make sprite move slightly faster over time
      // and zero-out sprite's velocity if its too low.
      if (sprite.body.velocity.x != 0) {

--- a/lib/actors/enemy-patdino.js
+++ b/lib/actors/enemy-patdino.js
@@ -63,6 +63,7 @@ import Attacks from '../helpers/attack-engine.js';
      }
 
      if (sprite.alive) {
+       // TODO: deal with equal case
        if (target.x < sprite.x) { // if target is to the left of PatDino
          sprite.data.direction = 'left';
        } else {
@@ -98,7 +99,7 @@ import Attacks from '../helpers/attack-engine.js';
    // * Non-busy action.
    stalk() {
      const { game, sprite, target } = this;
-     sprite.data.state == 'stalking';
+     sprite.data.state = 'stalking';
      sprite.animations.play('walk');
      sprite.busy = false;
      // http://phaser.io/docs/2.4.8/Phaser.Physics.Arcade.html#moveToObject
@@ -109,16 +110,20 @@ import Attacks from '../helpers/attack-engine.js';
 
    // * Injured = take damage and/or knockback, and play an injured animation.
    // * Busy action.
+   // TODO: Could probably separate animating & damaging (biz logic I guess?) concerns; injured() and damage() seem a bit muddied together right now
    injured(damage) {
      const { game, sprite } = this;
-     sprite.data.state == 'injured';
      sprite.busy = true;
+     sprite.data.state = 'injured';
+     // TODO: tune length of this anim, could prob hold longer
+     sprite.animations.play('injured').onComplete.add(function() {
+       sprite.data.state = 'stalking';
+       sprite.busy = false;
+     });
      sprite.damage(damage);
 
      // Update healthbar
      game.healthbars.updateHealthBar(sprite.name, sprite.health);
-
-     // once animation is done, restore stalking state and remove busy
    }
 
    // * Dead = health is zero; animate death and perform cleanup

--- a/lib/badguy_1.js
+++ b/lib/badguy_1.js
@@ -42,7 +42,7 @@ export default class Thug {
     // TODO: is this really needed anymore?
     this.sprite.name = this.name;
     this.sprite.health = this.health;
-    this.sprite.state = this.state;
+    this.sprite.data.state = this.state;
   }
 
   // * Add attackbox group

--- a/lib/badguy_1.js
+++ b/lib/badguy_1.js
@@ -84,6 +84,7 @@ export default class Thug {
     // this.sprite = this.game.add.sprite(this.game.camera.x + this.game.width, this.game.rnd.between(this.game.height/2 + 50, this.game.height-100), 'assets', 'bad_walk_01.png');
     this.name = `Thug-${id}`;
 
+    // TODO: save the x y area here for spawning the sprite as a spawnableArea property on game.js
     this.sprite = this.game.add.sprite(
       this.game.camera.x + this.game.width + 25,
       this.game.rnd.between(this.game.height/2 + 50,

--- a/lib/game.js
+++ b/lib/game.js
@@ -45,6 +45,24 @@ function create() {
     // this.game.add.sprite(0, 0, 'background');
 
     // Create actors
+
+    // Overwrite Phaser's damage function
+    // Use the onZeroHealth event to do something other than Phaser's default kill() function when health reaches zero
+    // onZeroHealth does not exist by default, so create onZeroHealth & add listeners on a per-actor basis (in _addSpriteEvents function)
+    Phaser.Sprite.prototype.damage = function(amount) {
+     if (this.alive) {
+       this.health -= amount;
+       if (this.health <= 0) {
+         if (this.events.onZeroHealth) {
+           this.events.onZeroHealth.dispatch(this);
+         } else {
+           this.kill(); // default Phaser action
+         }
+       }
+     }
+     return this;
+    }
+
     dudes = game.add.group();
     dudes.name = "EnemyGroup";
     playersGroup = game.add.group();

--- a/lib/game.js
+++ b/lib/game.js
@@ -45,8 +45,9 @@ function create() {
 
     // Create actors
     dudes = game.add.group();
-    dudes.name = "EnemiesGroup";
+    dudes.name = "EnemyGroup";
     playersGroup = game.add.group();
+    playersGroup.name = "PlayerGroup";
 
     player = new Player(game, 'One', dudes);
     player.create();
@@ -119,8 +120,8 @@ function update() {
 
       // Add PatDino
       let patDino = new PatDino(game, dudes, playersGroup);
+      thugs.push(patDino);
       patDino.create();
-      Debugger.showSpriteState(game, patDino)
 
       levels[currentLevel].state = 2;
       break;

--- a/lib/game.js
+++ b/lib/game.js
@@ -23,6 +23,7 @@ var dudes = null;
 var playersGroup = null;
 let HitDetectionEngine = null;
 let playerBar = null;
+let bossBar = null;
 
 function preload() {
     this.game.load.image('background', 'lib/assets/sprites/scene.png');
@@ -55,8 +56,8 @@ function create() {
     playersGroup.add(player.sprite);
 
     // Create UI
-    this.healthbars = new HealthBars(this.game);
-    playerBar = this.healthbars.renderPlayerHealthBar(player);
+    this.game.healthbars = new HealthBars(this.game);
+    playerBar = this.game.healthbars.renderPlayerHealthBar(player);
 
     // this.game.camera.follow(player.sprite);
     this.game.camera.x = player.sprite.x;
@@ -99,9 +100,10 @@ function create() {
 
 function update() {
   player.update();
-  this.healthbars.updateHealthBar(playerBar, player.health);
   //Debugger.showBodyInfo(game, playersGroup, dudes);
   //Debugger.showSpriteInfo(game, player.sprite);
+
+  let patDino;
 
   switch (levels[currentLevel].state) {
     case 0:
@@ -119,9 +121,11 @@ function update() {
       }
 
       // Add PatDino
-      let patDino = new PatDino(game, dudes, playersGroup);
+      patDino = new PatDino(game, dudes, playersGroup);
       thugs.push(patDino);
       patDino.create();
+      bossBar = this.game.healthbars.renderBossHealthBar(patDino.sprite);
+      console.log(this.game.healthbars)
 
       levels[currentLevel].state = 2;
       break;

--- a/lib/game.js
+++ b/lib/game.js
@@ -7,6 +7,7 @@ import HealthBars from './ui/healthbars.js';
 import HitDetection from './helpers/hit-detection.js';
 import Player from './player.js';
 import Thug from './badguy_1.js';
+import PatDino from './actors/enemy-patdino.js';
 
 import * as Debugger from './helpers/debug-commands.js';
 
@@ -115,6 +116,12 @@ function update() {
         thugs.push(thug)
         thug.create(i);
       }
+
+      // Add PatDino
+      let patDino = new PatDino(game, dudes, playersGroup);
+      patDino.create();
+      Debugger.showSpriteState(game, patDino)
+
       levels[currentLevel].state = 2;
       break;
     case 2:

--- a/lib/game.js
+++ b/lib/game.js
@@ -125,7 +125,6 @@ function update() {
       thugs.push(patDino);
       patDino.create();
       bossBar = this.game.healthbars.renderBossHealthBar(patDino.sprite);
-      console.log(this.game.healthbars)
 
       levels[currentLevel].state = 2;
       break;

--- a/lib/helpers/attack-engine.js
+++ b/lib/helpers/attack-engine.js
@@ -50,6 +50,7 @@ export default class Attacks {
     this.xPosLeft = xPosLeft;
     attackSprite.x = xPosRight; // default to face right
     attackSprite.y = yPos;
+    attackSprite.damageValue = damageValue;
   }
 
   // * Activate an attackbox on the sprite.

--- a/lib/helpers/debug-commands.js
+++ b/lib/helpers/debug-commands.js
@@ -1,7 +1,4 @@
 export function showBodyInfo(game, playersGroup, enemiesGroup) {
-  // Render "debug mode on" message
-  game.debug.text(`Debugging Hitboxes on Phaser ${Phaser.VERSION}`, 20, 20, 'yellow', 'Segoe UI');
-
   // Draw players' hitboxes & anchor point
   playersGroup.forEachAlive(function(sprite) {
     game.debug.body(sprite, "#9090ff", false)
@@ -22,4 +19,9 @@ export function showSpriteInfo(game, sprite) {
   // Print sprite info to screen
   game.debug.spriteBounds(sprite, "#9090ff", false)
   game.debug.spriteInfo(sprite, 32, 32);
+}
+
+export function showSpriteState(game, sprite) {
+  // Print sprite state on screen ('stalking', 'busy', etc.)
+  game.debug.text(`${sprite.name} state: ${sprite.state}`, game.width/2, 20, 'yellow', 'Segoe UI');
 }

--- a/lib/helpers/debug-commands.js
+++ b/lib/helpers/debug-commands.js
@@ -23,5 +23,5 @@ export function showSpriteInfo(game, sprite) {
 
 export function showSpriteState(game, sprite) {
   // Print sprite state on screen ('stalking', 'busy', etc.)
-  game.debug.text(`${sprite.name} state: ${sprite.state}`, game.width/2, 20, 'yellow', 'Segoe UI');
+  game.debug.text(`${sprite.name} state: ${sprite.data.state}`, game.width/2, 20, 'yellow', 'Segoe UI');
 }

--- a/lib/helpers/hit-detection.js
+++ b/lib/helpers/hit-detection.js
@@ -33,7 +33,7 @@ export default class HitDetection {
 
   registerHit(attackbox, targetSprite) {
     // Send an event to targetSprite to deal damage
-    targetSprite.events.isHit.dispatch(this);
+    targetSprite.events.isHit.dispatch(attackbox.damageValue);
     // TODO: Give attackbox properties such as damage, knockback, and send that through the isHit event too
   }
 

--- a/lib/helpers/proximity-detection.js
+++ b/lib/helpers/proximity-detection.js
@@ -43,3 +43,22 @@ function inZpace(game, close, far, targetPlayerY) {
   }
     return false;
 }
+
+/* Finds the sprite in the passed-in group that is closest to the calling sprite.
+ * @param {Phaser.Sprite} sprite - The sprite calling this function.
+ * @param {Phaser.Group} group - The group to search through for the nearest sprite.
+ */
+export function findNearestFromGroup(sprite, group) {
+  let closestSprite, distance;
+  group.forEachAlive(function(member) {
+    let newDistance = Phaser.Math.distance(
+      sprite.x, sprite.y,
+      member.x, member.y
+    );
+    if (distance == undefined || newDistance < distance) {
+      distance = newDistance;
+      closestSprite = member;
+    }
+  });
+  return closestSprite;
+}

--- a/lib/helpers/proximity-detection.js
+++ b/lib/helpers/proximity-detection.js
@@ -43,22 +43,3 @@ function inZpace(game, close, far, targetPlayerY) {
   }
     return false;
 }
-
-/* Finds the sprite in the passed-in group that is closest to the calling sprite.
- * @param {Phaser.Sprite} sprite - The sprite calling this function.
- * @param {Phaser.Group} group - The group to search through for the nearest sprite.
- */
-export function findNearestFromGroup(sprite, group) {
-  let closestSprite, distance;
-  group.forEachAlive(function(member) {
-    let newDistance = Phaser.Math.distance(
-      sprite.x, sprite.y,
-      member.x, member.y
-    );
-    if (distance == undefined || newDistance < distance) {
-      distance = newDistance;
-      closestSprite = member;
-    }
-  });
-  return closestSprite;
-}

--- a/lib/player.js
+++ b/lib/player.js
@@ -173,12 +173,13 @@ export default class Player {
     this.state = 'injured';
     // this.sprite.body.velocity.x = 0;
     // this.sprite.body.velocity.y = 0;
-    this.health -= 1;
+    this.sprite.health -= 5;
+    this.game.healthbars.updateHealthBar(this.name, this.sprite.health);
     this.lastDazedTime = new Date().getTime();
     this.busy = false;
     this.sprite.busy = false;
     this.sprite.animations.play('injured');
-    if(this.health <= 0) {
+    if(this.sprite.health <= 0) {
       setTimeout(function(){
         this.dead();
       }.bind(this), 200);

--- a/lib/ui/healthbars.js
+++ b/lib/ui/healthbars.js
@@ -5,6 +5,15 @@
 export default class HealthBars {
   constructor(game) {
     this.game = game;
+    this.bars = [];
+    this.updateHealthBar = function(barName, value) {
+      // Search bars array and update named bar
+      this.bars.forEach(function(bar) {
+        if (bar.name == barName) {
+          bar.setText(`${bar.name}: ${value}`)
+        }
+      });
+    };
   }
 
   renderPlayerHealthBar(player) {
@@ -12,22 +21,34 @@ export default class HealthBars {
       font: "16px Arial",
       fill: "#ff0044",
       wordWrap: true,
-      wordWrapWidth: 100,
+      wordWrapWidth: 300,
       align: "center",
       backgroundColor: "#ffff00"
     };
-    let bar = new Phaser.Graphics(this.game, 10, 10)
-    bar.lineTo(5000, 10);
-    bar.lineStyle(20, 1, 1)
-    this.game.add.text(10, 10, `${player.name}: `, style)
+    let bar = this.game.add.text(10, 10, `${player.health}: ${player.name}: `, style);
+    bar.name = player.name;
 
-    this.game.add.text(100, 10, `${player.health}`, style);
-
+    this.bars.push(bar);
     return bar;
   }
 
-  updateHealthBar(bar, value) {
-    //return bar.setText(value)
+  renderBossHealthBar(boss) {
+    const style = {
+      font: "16px Arial",
+      fill: "#ff0044",
+      wordWrap: true,
+      wordWrapWidth: 300,
+      align: "center",
+      backgroundColor: "#ffff00"
+    };
+    console.log(boss)
+
+    let bar = this.game.add.text(10, 40, `${boss.name}: ${boss.health}`, style);
+    bar.name = boss.name;
+
+    this.bars.push(bar);
+    return bar;
   }
+
   // TODO: probably a destroyHealthBar or replace health bar with "Press Start"/"Join Game" UI
 }

--- a/lib/ui/healthbars.js
+++ b/lib/ui/healthbars.js
@@ -41,7 +41,6 @@ export default class HealthBars {
       align: "center",
       backgroundColor: "#ffff00"
     };
-    console.log(boss)
 
     let bar = this.game.add.text(10, 40, `${boss.name}: ${boss.health}`, style);
     bar.name = boss.name;

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "babel-preset-es2015": "^6.3.13",
     "expose-loader": "",
     "script-loader": "^0.6.1",
-    "phaser": "photonstorm/phaser#dev"
+    "phaser": "^2.4.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,6 @@
     "babel-preset-es2015": "^6.3.13",
     "expose-loader": "",
     "script-loader": "^0.6.1",
-    "phaser": "^2.4.9"
+    "phaser": "^2.5.0"
   }
 }


### PR DESCRIPTION
Copy/pasted from CHANGELOG:
## v0.2.2 - 6/21/16
- Updated to Phaser v2.5.0 'Five Kings'
### New Features:
- Implemented a basic stub-in PatDino; right now he's just a giant Thug with a regular punch attack and just stalking.
- Added lo-fi health bars for the Player and PatDino; just names and numbers for now
### Under the Hood:
- Phaser introduced a `data` property for custom properties, so I'm starting to move our custom props such as `busy`, `state`, etc. under this. (Didn't do this across the board yet, so code is still messy and inconsistent)
- Starting to try to iron out the very important `busy` state; I haven't been using this consistently but I am trying to define it as "when the actor should not take damage", and hopefully will be able to clean up its usage across all actors soon, especially on the Player (who is still nukeable if attacked by multiple enemies at once).
- Created a new module for UI elements; currently handles just healthbars. It adds a `healthbars` property to the `game` object, allowing actors to hook into it via an `updateHealthBar` function. This allows healthbars to be created on the game level, while being updated by their actors.
- Instead of using our own damage counter, modified the one that already exists in Phaser, `Phaser.Sprite.prototype.damage` so, instead of immediately firing `kill()` and immediately removing the sprite when health reaches 0, it now fires a custom event `onZeroHealth` that we can use to hook into and play a death animation before firing `kill()`.
#### New Actor Properties:
- Added a new property for enemy actors called `target`, which is the Phaser Sprite that the enemy actor is going after. This is only implemented on PatDino right now, but it essentially replaces the `player` object currently used in the Thug actor, and is therefore set up for when multiple players are introduced.
  - Moving forward, instead of passing in a specific player into an enemy actor, we can use a new Phaser method `Group.getClosestTo(sprite)`, which can be used to find the player that is closest to that enemy sprite. That player becomes the enemy's target for stalking, chasing, and attacking.
  - Therefore, each enemy actor in particular needs an `opponentGroup` property, which is the Phaser Group that contains the players. (Or something else in the future, such as other enemies!)
  - This has not actually been tested with multiple players yet!
- Added `direction` to PatDino to save whether the sprite is facing right or left.
